### PR TITLE
Pull in missing library

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "compute-lcg": "^1.0.0",
     "dstructs-matrix": "^2.0.0",
     "validate.io-nonnegative": "^1.0.0",
+    "validate.io-number-primitive": "^1.0.0",
     "validate.io-object": "^1.0.4",
     "validate.io-positive-integer": "^1.0.0",
     "validate.io-positive-integer-array": "^1.0.0",


### PR DESCRIPTION
validate.io-number-primitive is a library that is loaded in lib/validate.js, but it is not currently pulled in by default. This will fix that.
